### PR TITLE
Add: execute_on_change parameter

### DIFF
--- a/manifests/reposync.pp
+++ b/manifests/reposync.pp
@@ -46,6 +46,10 @@
 #   by this define and it's executed every time this script is run (either
 #   manually or via Puppet). Default: ''
 #
+# [*execute_on_change*]
+#   Define if the pre_command and post_command will be execute at the same
+#   time as puppet (default) or only when change has been made into repository.
+#
 # [*basedir*]
 #   Directory where the git_reposync scripts are created.
 #   Default: /usr/local/sbin
@@ -87,20 +91,23 @@
 define git::reposync (
   $source_url,
   $destination_dir,
-  $extra_options   = '',
-  $branch          = 'master',
-  $autorun         = true,
-  $creates         = $destination_dir,
-  $pre_command     = '',
-  $post_command    = '',
-  $basedir         = '/usr/local/sbin',
-  $cron            = '',
-  $owner           = 'root',
-  $group           = 'root',
-  $mode            = '0755',
-  $ensure          = 'present' ) {
+  $extra_options     = '',
+  $branch            = 'master',
+  $autorun           = true,
+  $creates           = $destination_dir,
+  $pre_command       = '',
+  $post_command      = '',
+  $execute_on_change = false,
+  $basedir           = '/usr/local/sbin',
+  $cron              = '',
+  $owner             = 'root',
+  $group             = 'root',
+  $mode              = '0755',
+  $ensure            = 'present' ) {
 
   include git
+
+  $manage_execute_on_change = any2bool($execute_on_change)
 
   if ! defined(File['git_reposync']) {
     file { 'git_reposync':

--- a/templates/reposync/git_reposync-command.erb
+++ b/templates/reposync/git_reposync-command.erb
@@ -1,6 +1,19 @@
 #!/bin/bash
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
+<% if @manage_execute_on_change == true %>
+if [ ! -d <%= @destination_dir %> ] ; then
+  repo_commit="0"
+  local_commit="1"
+else
+  cd <%= @destination_dir %>
+  repo_commit=$( git ls-remote -h origin master|awk '{ print $1 }' )
+  local_commit=$( git rev-parse HEAD )
+fi
+
+if [ "$repo_commit" != "$local_commit" ] ; then
+<% end %>
+
 <%= @pre_command %>
 
 if [ ! -d <%= @destination_dir %> ] ; then
@@ -11,3 +24,7 @@ else
 fi
 
 <%= @post_command %>
+
+<% if @execute_on_change == true %>
+fi
+<% end %>


### PR DESCRIPTION
If execute_on_change is set to true the pre_command and post_command
will be execute only if change has been made on git repository. Default
value is false.

I'm not sure if 'execute_on_change' is the best name. 

Thank you for your hard work.
