### PR TITLE
Swap $destination_dir for $creates in reposync

### DIFF
--- a/templates/reposync/git_reposync-command.erb
+++ b/templates/reposync/git_reposync-command.erb
@@ -2,7 +2,7 @@
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 <% if @manage_execute_on_change == true %>
-if [ ! -d <%= @destination_dir %> ] ; then
+if [ ! -d <%= @creates %> ] ; then
   repo_commit="0"
   local_commit="1"
 else
@@ -16,7 +16,7 @@ if [ "$repo_commit" != "$local_commit" ] ; then
 
 <%= @pre_command %>
 
-if [ ! -d <%= @destination_dir %> ] ; then
+if [ ! -d <%= @creates %> ] ; then
   git clone --recursive <%= @source_url %> -b <%= @branch %> <%= @destination_dir %>
 else
   cd <%= @destination_dir %>


### PR DESCRIPTION
It appears that you should be able to pass in a "creates" param to reposync which will check for the given directory and only clone if that directory is not found. However, the reposync command template uses destination_dir directly in this check, rendering the feature broken. This PR fixes that issue.
