### PR TITLE
Fixed multiple execution on remote version pulling

### DIFF
--- a/templates/reposync/git_reposync-command.erb
+++ b/templates/reposync/git_reposync-command.erb
@@ -7,7 +7,7 @@ if [ ! -d <%= @destination_dir %> ] ; then
   local_commit="1"
 else
   cd <%= @destination_dir %>
-  repo_commit=$( git ls-remote -h origin master|awk '{ print $1 }' )
+  repo_commit=$( git ls-remote -h origin <%= @branch %>|awk '{ print $1 }' )
   local_commit=$( git rev-parse HEAD )
 fi
 


### PR DESCRIPTION
Current version rebuilds package every time when getting it from branch.
made change so when we are working on a branch - code gets executed only when there are new commits in this branch.